### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/udacity/sdc-issue-reports.png?label=ready&title=Ready)](https://waffle.io/udacity/sdc-issue-reports)
 # sdc-issue-reports
 
 You can use this repository to file issue reports with the Self-Driving Car Nanodegree content.


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/udacity/sdc-issue-reports

This was requested by a real person (user cameronwp) on waffle.io, we're not trying to spam you.